### PR TITLE
Support InstantTensor for AMD GPUs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,13 @@
 [submodule "csrc/third_party/dlpack"]
 	path = csrc/third_party/dlpack
-	url = git@github.com:dmlc/dlpack.git
+	url = https://github.com/dmlc/dlpack.git
 [submodule "csrc/third_party/pybind11"]
 	path = csrc/third_party/pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git
 [submodule "csrc/third_party/libaio"]
 	path = csrc/third_party/libaio
 	url = https://pagure.io/libaio.git
 [submodule "csrc/third_party/boost"]
 	path = csrc/third_party/boost
-	url = git@github.com:boostorg/boost.git
+	url = https://github.com/boostorg/boost.git
+	branch = boost-1.74.0

--- a/csrc/instant_tensor/dl_loader/cuda_loader.hpp
+++ b/csrc/instant_tensor/dl_loader/cuda_loader.hpp
@@ -60,26 +60,38 @@ inline bool init() {
         return true;
     }
 
+    // Try CUDA runtime first
     lib_handle = dl_loader_utils::find_loaded_so("cudart");
+
+    // If CUDA runtime not found, try HIP runtime (for AMD GPUs)
+    if (lib_handle == nullptr) {
+        lib_handle = dl_loader_utils::find_loaded_so("amdhip64");
+    }
+
     if (lib_handle == nullptr) {
         lib_handle = (void*)0x1;
         return false;
     }
 
     using dl_loader_utils::resolve;
-    cudaMalloc_fn = resolve<decltype(cudaMalloc_fn)>(lib_handle, "cudaMalloc");
-    cudaFree_fn = resolve<decltype(cudaFree_fn)>(lib_handle, "cudaFree");
-    cudaSetDevice_fn = resolve<decltype(cudaSetDevice_fn)>(lib_handle, "cudaSetDevice");
-    cudaStreamCreateWithFlags_fn = resolve<decltype(cudaStreamCreateWithFlags_fn)>(lib_handle, "cudaStreamCreateWithFlags");
-    cudaStreamDestroy_fn = resolve<decltype(cudaStreamDestroy_fn)>(lib_handle, "cudaStreamDestroy");
-    cudaMemcpyAsync_fn = resolve<decltype(cudaMemcpyAsync_fn)>(lib_handle, "cudaMemcpyAsync");
-    cudaEventCreateWithFlags_fn = resolve<decltype(cudaEventCreateWithFlags_fn)>(lib_handle, "cudaEventCreateWithFlags");
-    cudaEventRecord_fn = resolve<decltype(cudaEventRecord_fn)>(lib_handle, "cudaEventRecord");
-    cudaEventSynchronize_fn = resolve<decltype(cudaEventSynchronize_fn)>(lib_handle, "cudaEventSynchronize");
-    cudaStreamWaitEvent_fn = resolve<decltype(cudaStreamWaitEvent_fn)>(lib_handle, "cudaStreamWaitEvent");
-    cudaHostRegister_fn = resolve<decltype(cudaHostRegister_fn)>(lib_handle, "cudaHostRegister");
-    cudaHostUnregister_fn = resolve<decltype(cudaHostUnregister_fn)>(lib_handle, "cudaHostUnregister");
-    cudaGetErrorString_fn = resolve<decltype(cudaGetErrorString_fn)>(lib_handle, "cudaGetErrorString");
+    using dl_loader_utils::try_resolve;
+
+    // Try CUDA function names first (cuda* prefix), then HIP names (hip* prefix) as fallback
+    // On NVIDIA: libcudart.so has cuda* functions - uses CUDA path
+    // On AMD: libamdhip64.so only has hip* functions - uses HIP fallback path
+    cudaMalloc_fn = try_resolve<decltype(cudaMalloc_fn)>(lib_handle, "cudaMalloc", "hipMalloc");
+    cudaFree_fn = try_resolve<decltype(cudaFree_fn)>(lib_handle, "cudaFree", "hipFree");
+    cudaSetDevice_fn = try_resolve<decltype(cudaSetDevice_fn)>(lib_handle, "cudaSetDevice", "hipSetDevice");
+    cudaStreamCreateWithFlags_fn = try_resolve<decltype(cudaStreamCreateWithFlags_fn)>(lib_handle, "cudaStreamCreateWithFlags", "hipStreamCreateWithFlags");
+    cudaStreamDestroy_fn = try_resolve<decltype(cudaStreamDestroy_fn)>(lib_handle, "cudaStreamDestroy", "hipStreamDestroy");
+    cudaMemcpyAsync_fn = try_resolve<decltype(cudaMemcpyAsync_fn)>(lib_handle, "cudaMemcpyAsync", "hipMemcpyAsync");
+    cudaEventCreateWithFlags_fn = try_resolve<decltype(cudaEventCreateWithFlags_fn)>(lib_handle, "cudaEventCreateWithFlags", "hipEventCreateWithFlags");
+    cudaEventRecord_fn = try_resolve<decltype(cudaEventRecord_fn)>(lib_handle, "cudaEventRecord", "hipEventRecord");
+    cudaEventSynchronize_fn = try_resolve<decltype(cudaEventSynchronize_fn)>(lib_handle, "cudaEventSynchronize", "hipEventSynchronize");
+    cudaStreamWaitEvent_fn = try_resolve<decltype(cudaStreamWaitEvent_fn)>(lib_handle, "cudaStreamWaitEvent", "hipStreamWaitEvent");
+    cudaHostRegister_fn = try_resolve<decltype(cudaHostRegister_fn)>(lib_handle, "cudaHostRegister", "hipHostRegister");
+    cudaHostUnregister_fn = try_resolve<decltype(cudaHostUnregister_fn)>(lib_handle, "cudaHostUnregister", "hipHostUnregister");
+    cudaGetErrorString_fn = try_resolve<decltype(cudaGetErrorString_fn)>(lib_handle, "cudaGetErrorString", "hipGetErrorString");
 
     return true;
 }

--- a/csrc/instant_tensor/dl_loader/cufile_loader.hpp
+++ b/csrc/instant_tensor/dl_loader/cufile_loader.hpp
@@ -58,7 +58,15 @@ inline bool init() {
         return true;
     }
 
+    // Try cuFile first (NVIDIA GPUDirect Storage)
     lib_handle = dl_loader_utils::find_loaded_so("cufile");
+
+    // If cuFile not found, try hipFile (AMD GPUDirect Storage, if available)
+    // Note: AMD's hipFile may not be widely available yet, so this is forward-compatible
+    if (lib_handle == nullptr) {
+        lib_handle = dl_loader_utils::find_loaded_so("hipfile");
+    }
+
     if (lib_handle == nullptr) {
         lib_handle = (void*)0x1;
         return false;

--- a/csrc/instant_tensor/dl_loader/dl_loader_utils.hpp
+++ b/csrc/instant_tensor/dl_loader/dl_loader_utils.hpp
@@ -37,5 +37,29 @@ inline T resolve(void* handle, const char* name) {
     return reinterpret_cast<T>(sym);
 }
 
+// Try to resolve a symbol with a primary name, falling back to an alternative name so that CUDA and HIP are supported.
+template <typename T>
+inline T try_resolve(void* handle, const char* primary_name, const char* fallback_name) {
+    // Clear any previous error
+    dlerror();
+
+    void* sym = dlsym(handle, primary_name);
+    if (sym) {
+        return reinterpret_cast<T>(sym);
+    }
+
+    // Try fallback name
+    dlerror(); // Clear error from first attempt
+    sym = dlsym(handle, fallback_name);
+    if (sym) {
+        return reinterpret_cast<T>(sym);
+    }
+
+    throw std::runtime_error(
+        std::string("failed to resolve ") + primary_name +
+        " or " + fallback_name + ": " + dlerror()
+    );
+}
+
 } // namespace dl_loader_utils
 } // namespace instanttensor

--- a/csrc/instant_tensor/dl_loader/nccl_loader.hpp
+++ b/csrc/instant_tensor/dl_loader/nccl_loader.hpp
@@ -33,13 +33,21 @@ inline bool init() {
         return true;
     }
 
+    // Try NCCL first (NVIDIA)
     lib_handle = dl_loader_utils::find_loaded_so("nccl");
+
+    // If NCCL not found, try RCCL (AMD's NCCL for ROCm)
+    if (lib_handle == nullptr) {
+        lib_handle = dl_loader_utils::find_loaded_so("rccl");
+    }
+
     if (lib_handle == nullptr) {
         lib_handle = (void*)0x1;
         return false;
     }
 
     using dl_loader_utils::resolve;
+    // RCCL provides NCCL-compatible API (same function names and signatures)
     ncclAllGather_fn = resolve<decltype(ncclAllGather_fn)>(lib_handle, "ncclAllGather");
     ncclCommUserRank_fn = resolve<decltype(ncclCommUserRank_fn)>(lib_handle, "ncclCommUserRank");
     ncclCommCount_fn = resolve<decltype(ncclCommCount_fn)>(lib_handle, "ncclCommCount");

--- a/csrc/instant_tensor/dlpack_utils.hpp
+++ b/csrc/instant_tensor/dlpack_utils.hpp
@@ -7,6 +7,8 @@
 #include <cstring>
 #include <vector>
 #include <dlpack/dlpack.h>
+#include <instant_tensor/dl_loader/cuda_loader.hpp>
+
 namespace py = pybind11;
 
 namespace instanttensor {
@@ -102,7 +104,44 @@ static DLDataType torch_to_dlpack_dtype(const std::string& s) {
     }
 }
 
-// ptr: uint64 (CUDA device pointer)
+// Detect the device type based on the loaded runtime library
+static DLDeviceType get_device_type() {
+    static DLDeviceType cached_type = static_cast<DLDeviceType>(-1);
+    if (cached_type != static_cast<DLDeviceType>(-1)) {
+        return cached_type;
+    }
+
+    // Ensure cuda_loader is initialized
+    if (!cuda_loader::init()) {
+        // Failed to initialize - default to CUDA for backward compatibility
+        cached_type = kDLCUDA;
+        return cached_type;
+    }
+
+    // Check which runtime library is loaded
+    void* cudart_handle = cuda_loader::lib_handle;
+    if (cudart_handle == nullptr || cudart_handle == (void*)0x1) {
+        // Default to CUDA for NVIDIA compatibility
+        cached_type = kDLCUDA;
+        return cached_type;
+    }
+
+    // Detect AMD HIP by checking for HIP-specific symbol
+    // This only affects AMD systems - NVIDIA CUDA runtime won't have this symbol
+    dlerror(); // Clear any previous error
+    void* hip_symbol = dlsym(cudart_handle, "hipGetDeviceCount");
+    if (hip_symbol != nullptr) {
+        // It's HIP (AMD ROCm) - use kDLROCM device type
+        cached_type = kDLROCM;
+    } else {
+        // It's CUDA (NVIDIA) - use kDLCUDA device type (default)
+        cached_type = kDLCUDA;
+    }
+
+    return cached_type;
+}
+
+// ptr: uint64 (CUDA/HIP device pointer)
 // shape: vector<int64_t>
 // dtype: string ("float32" etc.)
 // device_id: int
@@ -133,7 +172,8 @@ static py::object pack_dlpack(uint64_t ptr,
         ctx->strides = nullptr;
     }
     managed->dl_tensor.data = reinterpret_cast<void*>(ptr);
-    managed->dl_tensor.device = DLDevice{kDLCUDA, device_id};
+    // Use the appropriate device type (kDLCUDA for NVIDIA, kDLROCM for AMD)
+    managed->dl_tensor.device = DLDevice{get_device_type(), device_id};
     managed->dl_tensor.ndim = ctx->ndim;
     managed->dl_tensor.dtype = torch_to_dlpack_dtype(dtype);
     managed->dl_tensor.shape = ctx->shape;


### PR DESCRIPTION
This PR is to add AMD GPU support to InstantTensor by implementing HIP/ROCm compatibility. The functionality is validated on AMD MI355 GPUs by passing the unit test script from tests/test.py and the E2E SGLang framework integration from https://github.com/sgl-project/sglang/pull/20335:



The implementation provides transparent compatibility between:

| Component | NVIDIA | AMD | Detection Method |
|-----------|--------|-----|------------------|
| Runtime | CUDA (`libcudart.so`) | HIP (`libamdhip64.so`) | Library discovery in `/proc/self/maps` |
| Functions | `cuda*` prefix | `hip*` prefix | Symbol resolution with fallback |
| Collective Comm | NCCL (`libnccl.so`) | RCCL (`librccl.so`) | Library discovery |
| DLPack Device | `kDLCUDA` (2) | `kDLROCM` (10) | Runtime symbol check |
| Direct Storage | cuFile (optional) | hipFile (optional) | Graceful fallback |


## Test Configuration
**Server Command**:
```bash
  SGLANG_USE_AITER=1 SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 SGLANG_INT4_WEIGHT=0 \
  SGLANG_MOE_PADDING=1 SGLANG_SET_CPU_AFFINITY=1 SGLANG_ROCM_FUSED_DECODE_MLA=1 \
  SGLANG_USE_ROCM700A=1 python3 -m sglang.launch_server \
  --model-path amd/DeepSeek-R1-MXFP4-Preview --tp-size 4 --ep-size 4 \
  --speculative-algorithm EAGLE --speculative-num-steps 3 \
  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
  --speculative-attention-mode decode \
  --speculative-draft-model-path lmsys/DeepSeek-R1-NextN \
  --trust-remote-code --mem-fraction-static 0.8 --attention-backend aiter \
  --chunked-prefill-size 131072 --disable-radix-cache --kv-cache-dtype fp8_e4m3 \
  --max-running-requests 512 \
  [--load-format instanttensor]
```

## GSM8K Warmup & Accuracy Verification
**Client Command**:
```
python3 benchmark/gsm8k/bench_sglang.py --parallel 1319 --num-questions 1319
```
| Configuration | Accuracy | Latency | Output Throughput |
|--------------|----------|---------|-------------------|
| **Without InstantTensor** | 94.6% | 58.6s | 2213.9 tok/s |
| **With InstantTensor** | 94.4% | 59.1s | 2198.6 tok/s |


## Serving Benchmark Results
**Client Command**:
```
python3 -m sglang.bench_serving --backend sglang-oai-chat --model /data/amd/DeepSeek-R1-MXFP4-Preview --dataset-name random --seed 5 --random-input-len 3500 --random-output-len 1500 --num-prompts 768 --max-concurrency 448 --request-rate 5 --random-range-ratio 1.0

```
### Key Performance Metrics

| Metric | Without InstantTensor | With InstantTensor | Difference | Change |
|--------|----------------------|-------------------|------------|--------|
| **Total Token Throughput (tok/s)** | 14,304.27 | 14,324.52 | +20.25 | **+0.14%** ✅ |
| **Mean E2E Latency (ms)** | 113,957.96 | 113,843.16 | -114.80 | **-0.10%** ✅ |
| **Mean TTFT (ms)** | 383.02 | 314.01 | -69.01 | **-18.0%** ✅ |
| **Mean TPOT (ms)** | 75.77 | 75.74 | -0.03 | **-0.04%** ≈ |


### Detailed Comparison

#### Throughput Metrics

| Metric | Without InstantTensor | With InstantTensor | Difference |
|--------|----------------------|-------------------|------------|
| Request Throughput (req/s) | 2.86 | 2.87 | +0.01 |
| Input Token Throughput (tok/s) | 10,012.13 | 10,026.30 | +14.17 |
| Output Token Throughput (tok/s) | 4,292.14 | 4,298.21 | +6.07 |
| **Total Token Throughput (tok/s)** | **14,304.27** | **14,324.52** | **+20.25** |
| Peak Output Token Throughput (tok/s) | 3,659.00 | 4,030.00 | +371.00 |
| Peak Concurrent Requests | 457 | 456 | -1 |
| Concurrency | 326.08 | 326.21 | +0.13 |

#### End-to-End Latency

| Metric | Without InstantTensor | With InstantTensor | Difference |
|--------|----------------------|-------------------|------------|
| **Mean E2E Latency (ms)** | **113,957.96** | **113,843.16** | **-114.80** |
| Median E2E Latency (ms) | 120,715.03 | 120,954.02 | +238.99 |
| P90 E2E Latency (ms) | 141,828.83 | 142,849.02 | +1,020.19 |
| P99 E2E Latency (ms) | 156,975.59 | 157,541.90 | +566.31 |

#### Time to First Token (TTFT)

| Metric | Without InstantTensor | With InstantTensor | Difference | Change |
|--------|----------------------|-------------------|------------|--------|
| **Mean TTFT (ms)** | **383.02** | **314.01** | **-69.01** | **-18.0%** ✅ |
| Median TTFT (ms) | 304.71 | 289.76 | -14.95 | -4.9% |
| P99 TTFT (ms) | 2,440.70 | 713.10 | -1,727.60 | **-70.8%** ✅ |

#### Time Per Output Token (TPOT)

| Metric | Without InstantTensor | With InstantTensor | Difference |
|--------|----------------------|-------------------|------------|
| **Mean TPOT (ms)** | **75.77** | **75.74** | **-0.03** |
| Median TPOT (ms) | 79.84 | 80.52 | +0.68 |
| P99 TPOT (ms) | 104.46 | 104.88 | +0.42 |

#### Inter-Token Latency (ITL)

| Metric | Without InstantTensor | With InstantTensor | Difference |
|--------|----------------------|-------------------|------------|
| Mean ITL (ms) | 76.01 | 75.96 | -0.05 |
| Median ITL (ms) | 43.24 | 43.68 | +0.44 |
| P95 ITL (ms) | 239.01 | 242.12 | +3.11 |
| P99 ITL (ms) | 485.54 | 490.46 | +4.92 |
| Max ITL (ms) | 7,625.13 | 2,231.53 | -5,393.60 |


✅ **18% faster Time to First Token** (383ms → 314ms)
✅ **71% lower P99 TTFT** (2,441ms → 713ms)
✅ **10% higher peak throughput** (3,659 → 4,030 tok/s)
✅ **Identical overall throughput and latency**
✅ **More predictable latency** (71% lower max ITL)
✅ **No accuracy degradation** (94.5% GSM8K)