### PR TITLE
Setup cibuildwheel to pre-build wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -2,9 +2,8 @@ name: Build and Publish Wheels
 
 on:
   push:
-    # TODO: only enable on tagged releases
-    # tags:
-    #   - "v*"
+    tags:
+      - "v*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,28 @@
+name: Build and Publish Wheels
+
+on:
+  push:
+    # TODO: only enable on tagged releases
+    # tags:
+    #   - "v*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_wheels:
+    name: Build wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: pypa/cibuildwheel@v3.4.0
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels
+          path: ./wheelhouse/*.whl
+  # TODO: automatically publish

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 *.so.*
 
 # Distribution / packaging
+wheelhouse/
 .Python
 build/
 cmake-build-*/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,5 @@ include = ["instanttensor*"]
 [tool.cibuildwheel]
 build = "cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64"
 
+before-test = "pip install torch --index-url https://download.pytorch.org/whl/cpu"
 test-command = "python -c \"from instanttensor import safe_open\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,8 @@ test = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["instanttensor*"]
+
+[tool.cibuildwheel]
+build = "cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64"
+
+test-command = "python -c \"from instanttensor import safe_open\""


### PR DESCRIPTION
@arlo-scitix Thanks for open sourcing InstantTensor and [integrating it into vllm](https://github.com/vllm-project/vllm/pull/36139).

This PR adds a minimal [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/) config and a GitHub actions workflow which builds wheels ready to be published to PyPI.

A successful wheel build run on CI for Python 3.10-3.13 can be found [here](https://github.com/lgeiger/InstantTensor/actions/runs/23322260735).

This PR doesn't add any automatic publishing mechanism as this is best left to the maintainers. But the wheels are ready to be uploaded to PyPI, e.g. via https://github.com/pypa/gh-action-pypi-publish as recommended in [cibuildwheel docs](https://cibuildwheel.pypa.io/en/stable/deliver-to-pypi/) or twine.

Closes #3