### PR TITLE
feat: add io_uring buffered load path (INSTANTTENSOR_USE_URING=1)

### DIFF
--- a/csrc/instant_tensor/async_executor.hpp
+++ b/csrc/instant_tensor/async_executor.hpp
@@ -27,7 +27,9 @@ public:
 
     template<typename F>
     int post(F&& f) {
-        int id = next_id.fetch_add(1, std::memory_order_relaxed);
+        int id = next_id;
+        if(next_id < INT_MAX) next_id++;
+        else next_id = 1; // skip 0
 
         Task t = [fn = std::forward<F>(f)]() mutable -> std::any {
             using R = std::invoke_result_t<decltype(fn)>;
@@ -138,8 +140,8 @@ private:
     SPSCQueue<WorkPair, OutputQueueCapacity>      output_queue;
     std::unordered_map<int,std::any> result_buffer; // cache out-of-order results
 
-    std::atomic<int>         next_id;
-    std::thread              worker;
+    int         next_id;
+    std::thread worker;
 
     void run() {
         WorkItem w;

--- a/csrc/instant_tensor/common.hpp
+++ b/csrc/instant_tensor/common.hpp
@@ -131,6 +131,12 @@ inline bool _env_use_uring(){
     return ret;
 }
 
+// Enable O_DIRECT for libaio/io_uring
+inline bool _env_direct_io(){
+    static bool ret = get_env("INSTANTTENSOR_DIRECT_IO").value_or("1") == "1";
+    return ret;
+}
+
 inline bool _env_debug() {
     static bool ret = get_env("INSTANTTENSOR_DEBUG").value_or("0") == "1";
     return ret;

--- a/csrc/instant_tensor/common.hpp
+++ b/csrc/instant_tensor/common.hpp
@@ -126,6 +126,11 @@ inline bool _env_cache_buffer(){
     return ret;
 }
 
+inline bool _env_use_uring(){
+    static bool ret = get_env("INSTANTTENSOR_USE_URING").value_or("0") == "1";
+    return ret;
+}
+
 inline bool _env_debug() {
     static bool ret = get_env("INSTANTTENSOR_DEBUG").value_or("0") == "1";
     return ret;

--- a/csrc/instant_tensor/loader.hpp
+++ b/csrc/instant_tensor/loader.hpp
@@ -3,6 +3,7 @@
 #include <instant_tensor/common.hpp>
 #include <instant_tensor/types.hpp>
 #include <instant_tensor/io_context.hpp>
+#include <liburing.h>
 
 namespace instanttensor {
 
@@ -69,6 +70,14 @@ public:
     vector<struct iocb*> aio_iocb_ptrs;
     vector<struct io_event> aio_events;
 
+    // io_uring (loader_io_uring.cpp)
+    // All io_uring calls happen exclusively on uring_thread (SPSC: main posts, cuda_thread pops).
+    // This matches the aio_fallback_thread pattern and avoids concurrent SQ/CQ access.
+    bool need_uring = false;
+    struct io_uring uring_ring = {};
+    size_t uring_ring_size = 0;
+    unique_ptr<AsyncExecutor> uring_thread;
+
     int device_idx = -1;
     ncclComm_t group_communicator = nullptr;
     int rank = -1;
@@ -125,6 +134,13 @@ public:
     void close_file_aio(FileInfo &f);    // close fd
     void close_file_aio_context();       // io_destroy
     ChunkRequest post_read_chunk_aio(const ChunkIOParams &p);
+
+    // io_uring path (loader_io_uring.cpp)
+    void open_file_uring(FileInfo &f);   // open fd (buffered, no O_DIRECT), fadvise
+    void open_uring_context();           // io_uring_queue_init
+    void close_file_uring(FileInfo &f);  // close fd
+    void close_uring_context();          // io_uring_queue_exit
+    ChunkRequest post_read_chunk_uring(const ChunkIOParams &p);
 };
 
 void run_loader(unique_ptr<SPSCQueue<RPCRequest>> input_queue, unique_ptr<SPSCQueue<RPCResponse>> output_queue);

--- a/csrc/instant_tensor/loader.hpp
+++ b/csrc/instant_tensor/loader.hpp
@@ -35,6 +35,7 @@ public:
     bool need_host_buffer = false;
     bool need_cufile = false;
     bool need_aio = false;
+    bool need_uring = false;
     bool need_worker_threads = false;
     bool need_cuda_thread = false;
     void *device_buffer = nullptr;
@@ -44,7 +45,9 @@ public:
     vector<Chunk> chunks;
     size_t current_tensor_index = 0;
     vector<unique_ptr<AsyncExecutor>> worker_threads;
-    unique_ptr<AsyncExecutor> aio_fallback_thread;
+    // A special thread to read the last page of a file when the file size is not page aligned, 
+    // which results in blocking I/O even with O_DIRECT and libaio/io_uring.
+    unique_ptr<AsyncExecutor> last_page_reader_thread; 
     unique_ptr<AsyncExecutor> cuda_thread;
     unique_ptr<AsyncExecutor> wait_thread;
     std::thread io_depth_sample_thread;
@@ -71,12 +74,7 @@ public:
     vector<struct io_event> aio_events;
 
     // io_uring (loader_io_uring.cpp)
-    // All io_uring calls happen exclusively on uring_thread (SPSC: main posts, cuda_thread pops).
-    // This matches the aio_fallback_thread pattern and avoids concurrent SQ/CQ access.
-    bool need_uring = false;
     struct io_uring uring_ring = {};
-    size_t uring_ring_size = 0;
-    unique_ptr<AsyncExecutor> uring_thread;
 
     int device_idx = -1;
     ncclComm_t group_communicator = nullptr;

--- a/csrc/instant_tensor/types.hpp
+++ b/csrc/instant_tensor/types.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <instant_tensor/common.hpp>
 
 namespace instanttensor {
@@ -69,7 +70,7 @@ struct TensorMetadate {
 };
 
 struct ChunkExtraData {
-    size_t aio_unfinished_cnt;
+    size_t unfinished_cnt;
 };
 
 struct ChunkRequest {

--- a/csrc/loader_common.cpp
+++ b/csrc/loader_common.cpp
@@ -135,14 +135,9 @@ void Loader::init_threads() {
             this->cuda_thread = std::make_unique<AsyncExecutor>();
         }
     }
-    if(this->need_aio) {
-        if(!this->aio_fallback_thread) {
-            this->aio_fallback_thread = std::make_unique<AsyncExecutor>();
-        }
-    }
-    if(this->need_uring) {
-        if(!this->uring_thread) {
-            this->uring_thread = std::make_unique<AsyncExecutor>();
+    if(this->need_aio || this->need_uring) {
+        if(!this->last_page_reader_thread) {
+            this->last_page_reader_thread = std::make_unique<AsyncExecutor>();
         }
     }
 
@@ -162,8 +157,8 @@ void Loader::init_threads() {
     if(this->cuda_thread) {
         this->cuda_thread->post(set_device_func);
     }
-    if(this->aio_fallback_thread) {
-        this->aio_fallback_thread->post(set_device_func);
+    if(this->last_page_reader_thread) {
+        this->last_page_reader_thread->post(set_device_func);
     }
     if(this->wait_thread) {
         this->wait_thread->post(set_device_func);
@@ -191,11 +186,8 @@ void Loader::destroy_threads() {
     if (this->cuda_thread) {
         this->cuda_thread->join();
     }
-    if (this->aio_fallback_thread) {
-        this->aio_fallback_thread->join();
-    }
-    if (this->uring_thread) {
-        this->uring_thread->join();
+    if (this->last_page_reader_thread) {
+        this->last_page_reader_thread->join();
     }
     if (this->wait_thread) {
         this->wait_thread->join();

--- a/csrc/loader_common.cpp
+++ b/csrc/loader_common.cpp
@@ -7,6 +7,7 @@ Loader::Loader(unique_ptr<SPSCQueue<RPCRequest>> input_queue, unique_ptr<SPSCQue
     this->output_queue = std::move(output_queue);
     this->use_internal_memory_register = _env_use_internal_memory_register();
     this->use_cufile = _env_use_cufile();
+    // _env_use_uring() is checked at open_file() time, stored in need_uring
 }
 
 void Loader::open_file() {
@@ -18,12 +19,17 @@ void Loader::open_file() {
             this->open_file_inmem(f);
         } else if (this->use_cufile) {
             this->open_file_cufile(f);
+        } else if (_env_use_uring()) {
+            this->open_file_uring(f);
         } else {
             this->open_file_aio(f);
         }
     }
     if(this->need_aio) {
         this->open_file_aio_context();
+    }
+    if(this->need_uring) {
+        this->open_uring_context();
     }
 }
 
@@ -34,12 +40,17 @@ void Loader::close_file() {
             this->close_file_inmem(f);
         } else if (this->use_cufile) {
             this->close_file_cufile(f);
+        } else if (this->need_uring) {
+            this->close_file_uring(f);
         } else {
             this->close_file_aio(f);
         }
     }
     if(this->need_aio) {
         this->close_file_aio_context();
+    }
+    if(this->need_uring) {
+        this->close_uring_context();
     }
 }
 
@@ -129,6 +140,11 @@ void Loader::init_threads() {
             this->aio_fallback_thread = std::make_unique<AsyncExecutor>();
         }
     }
+    if(this->need_uring) {
+        if(!this->uring_thread) {
+            this->uring_thread = std::make_unique<AsyncExecutor>();
+        }
+    }
 
     if(!this->cuda_stream) {
         CUDA_CHECK(cudaStreamCreateWithFlags(&this->cuda_stream, cudaStreamNonBlocking));
@@ -177,6 +193,9 @@ void Loader::destroy_threads() {
     }
     if (this->aio_fallback_thread) {
         this->aio_fallback_thread->join();
+    }
+    if (this->uring_thread) {
+        this->uring_thread->join();
     }
     if (this->wait_thread) {
         this->wait_thread->join();
@@ -452,6 +471,8 @@ void Loader::post_read_chunk() {
         result = this->post_read_chunk_inmem(params);
     } else if (this->use_cufile) {
         result = this->post_read_chunk_cufile(params);
+    } else if (this->need_uring) {
+        result = this->post_read_chunk_uring(params);
     } else {
         result = this->post_read_chunk_aio(params);
     }

--- a/csrc/loader_io_aio.cpp
+++ b/csrc/loader_io_aio.cpp
@@ -3,13 +3,21 @@
 namespace instanttensor {
 
 void Loader::open_file_aio(FileInfo &f) {
-    f.fd = ::open(f.filename.c_str(), O_RDONLY | O_DIRECT);
+    int open_flags = O_RDONLY;
+    if (_env_direct_io()) {
+        open_flags |= O_DIRECT;
+    }
+    f.fd = ::open(f.filename.c_str(), open_flags);
     if (f.fd < 0) {
         throw std::runtime_error("Failed to open file: " + f.filename);
     }
     struct stat st;
     if (fstat(f.fd, &st) < 0) { throw std::runtime_error("Failed to fstat file: " + f.filename); }
     f.size = st.st_size;
+
+    if (!_env_direct_io()) {
+        posix_fadvise(f.fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+    }
 
     this->need_aio = true;
     this->need_host_buffer = true;
@@ -61,7 +69,7 @@ ChunkRequest Loader::post_read_chunk_aio(const ChunkIOParams &p) {
         iocb->data = (void*)chunk_id;
         submit_cnt ++;
     }
-    this->chunks[chunk_id].extra_data.aio_unfinished_cnt = submit_cnt;
+    this->chunks[chunk_id].extra_data.unfinished_cnt = submit_cnt;
 
     // NOTE: This will block at the last page of the file if the file is not page aligned.
     //       So we put the last page into another thread
@@ -73,11 +81,13 @@ ChunkRequest Loader::post_read_chunk_aio(const ChunkIOParams &p) {
     };
 
     int aio_req_id = 0;
-    if(unaligned_last_page) {
-        aio_req_id = this->aio_fallback_thread->post(std::move(aio_func));
-    }
-    else {
-        aio_func();
+    if(submit_cnt > 0) {
+        if(unaligned_last_page) {
+            aio_req_id = this->last_page_reader_thread->post(std::move(aio_func));
+        }
+        else {
+            aio_func();
+        }
     }
     
 
@@ -88,11 +98,11 @@ ChunkRequest Loader::post_read_chunk_aio(const ChunkIOParams &p) {
     size_t padded_rank_size = p.padded_rank_size;
     cudaEvent_t event = p.event;
     auto cuda_func = [=]() {
-        if(unaligned_last_page) {
-            this->aio_fallback_thread->pop(aio_req_id);
+        if(aio_req_id) {
+            this->last_page_reader_thread->pop(aio_req_id);
         }
         // disk to host
-        size_t &unfinished_cnt = this->chunks[chunk_id].extra_data.aio_unfinished_cnt;
+        size_t &unfinished_cnt = this->chunks[chunk_id].extra_data.unfinished_cnt;
         while(unfinished_cnt > 0) {
             int got = io_getevents(this->aio_ctx, unfinished_cnt, unfinished_cnt, this->aio_events.data(), NULL);
             // got may < min_nr and >= 0 if interrupted
@@ -107,7 +117,7 @@ ChunkRequest Loader::post_read_chunk_aio(const ChunkIOParams &p) {
                 }
                 // NOTE: event_chunk_id can be different from chunk_id
                 chunk_id_t event_chunk_id = (chunk_id_t)this->aio_events[i].data;
-                this->chunks[event_chunk_id].extra_data.aio_unfinished_cnt --;
+                this->chunks[event_chunk_id].extra_data.unfinished_cnt --;
             }
         }
 

--- a/csrc/loader_io_uring.cpp
+++ b/csrc/loader_io_uring.cpp
@@ -8,7 +8,7 @@ namespace instanttensor {
 // uring_thread (an SPSCAsyncExecutor).  The main loader thread is the only
 // producer; cuda_thread is the only consumer (via uring_thread->pop).
 //
-// This mirrors the existing aio_fallback_thread pattern and avoids any
+// This mirrors the existing last_page_reader_thread pattern and avoids any
 // concurrent access to the liburing userspace state, which is not thread-safe.
 //
 // Within each chunk, the uring_func submits num_threads SQEs simultaneously
@@ -22,7 +22,11 @@ namespace instanttensor {
 void Loader::open_file_uring(FileInfo &f) {
     // Buffered fd — no O_DIRECT.  Page-cache reads are done by kernel io-wq
     // workers, which is what makes them truly async with io_uring.
-    f.fd = ::open(f.filename.c_str(), O_RDONLY);
+    int open_flags = O_RDONLY;
+    if (_env_direct_io()) {
+        open_flags |= O_DIRECT;
+    }
+    f.fd = ::open(f.filename.c_str(), open_flags);
     if (f.fd < 0) {
         throw std::runtime_error("Failed to open file: " + f.filename);
     }
@@ -34,7 +38,9 @@ void Loader::open_file_uring(FileInfo &f) {
 
     // Hint sequential access so the VFS read-ahead fills the page cache ahead
     // of our reads and reduces the time spent in the io-wq workers.
-    posix_fadvise(f.fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+    if (!_env_direct_io()) {
+        posix_fadvise(f.fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+    }
 
     this->need_uring       = true;
     this->need_host_buffer = true;
@@ -42,15 +48,7 @@ void Loader::open_file_uring(FileInfo &f) {
 }
 
 void Loader::open_uring_context() {
-    // Ring depth must cover io_depth × num_threads in-flight SQEs.
-    // io_uring_queue_init rounds up internally, but we round up ourselves too
-    // to ensure the ring can hold all in-flight entries without blocking.
-    unsigned needed = (unsigned)(this->io_depth * this->num_threads);
-    unsigned ring_entries = 1;
-    while (ring_entries < needed) ring_entries <<= 1;
-    this->uring_ring_size = ring_entries;
-
-    int ret = io_uring_queue_init(ring_entries, &this->uring_ring, 0);
+    int ret = io_uring_queue_init((unsigned)(this->io_depth * this->num_threads), &this->uring_ring, 0);
     if (ret < 0) {
         throw std::runtime_error(
             "io_uring_queue_init failed: " + std::string(strerror(-ret)));
@@ -79,14 +77,19 @@ struct UringReadOp {
 ChunkRequest Loader::post_read_chunk_uring(const ChunkIOParams &p) {
     // Build the per-thread read descriptors on the main thread (no io_uring
     // calls here — those happen exclusively on uring_thread below).
+    chunk_id_t chunk_id = p.chunk_id;
     std::vector<UringReadOp> ops;
     ops.reserve(this->num_threads);
+
+    bool unaligned_last_page = false;
 
     for (size_t i = 0; i < this->num_threads; i++) {
         size_t thread_offset = p.padded_thread_size * i;
         size_t thread_size   = std::min(
             (size_t)std::max((ssize_t)(p.chunk.size - p.rank_offset - thread_offset), (ssize_t)0),
             p.padded_thread_size);
+        size_t thread_size_aligned = ROUND_UP(thread_size, this->thread_alignment);
+        if(thread_size != thread_size_aligned) unaligned_last_page = true;
         if (thread_size == 0) continue;
 
         ops.push_back(UringReadOp{
@@ -97,55 +100,39 @@ ChunkRequest Loader::post_read_chunk_uring(const ChunkIOParams &p) {
         });
     }
 
-    // ── uring_func: runs on uring_thread ─────────────────────────────────────
-    // Submits all SQEs then waits for exactly that many CQEs.
-    // Because uring_thread is sequential and chunk N's SQEs are the only ones
-    // in-flight at this point, every CQE must belong to chunk N — no cross-
-    // chunk dispatch needed.
-    auto uring_func = [this, ops = std::move(ops)]() {
-        const size_t submit_cnt = ops.size();
-        if (submit_cnt == 0) return;
-
-        for (const auto &op : ops) {
-            struct io_uring_sqe *sqe = io_uring_get_sqe(&this->uring_ring);
-            if (!sqe) {
-                throw std::runtime_error(
-                    "io_uring SQ full (ring_entries=" +
-                    std::to_string(this->uring_ring_size) + ")");
-            }
-            // Buffered read: no alignment constraints, use exact byte range.
-            io_uring_prep_read(sqe, op.fd, op.buf,
-                               (unsigned)op.size, op.file_offset);
+    for (const auto &op : ops) {
+        struct io_uring_sqe *sqe = io_uring_get_sqe(&this->uring_ring);
+        if (!sqe) {
+            throw std::runtime_error(
+                "io_uring SQ full");
         }
+        // Buffered read: no alignment constraints, use exact byte range.
+        io_uring_prep_read(sqe, op.fd, op.buf,
+                        (unsigned)op.size, op.file_offset);
+        io_uring_sqe_set_data(sqe, (void*)p.chunk_id); // type of user_data is __u64
+    }
+    this->chunks[chunk_id].extra_data.unfinished_cnt = ops.size();
+    const size_t submit_cnt = ops.size();
 
+    int uring_req_id = 0;
+    auto uring_func = [=]() {
         int submitted = io_uring_submit(&this->uring_ring);
         if (submitted < 0) {
             throw std::runtime_error(
                 "io_uring_submit failed: " + std::string(strerror(-submitted)));
         }
-
-        // Wait for all submitted reads to complete.
-        // io_uring_wait_cqe blocks until at least one CQE is available;
-        // the kernel's io-wq workers are doing the actual I/O in parallel.
-        for (size_t done = 0; done < submit_cnt; done++) {
-            struct io_uring_cqe *cqe;
-            int ret = io_uring_wait_cqe(&this->uring_ring, &cqe);
-            if (ret < 0) {
-                throw std::runtime_error(
-                    "io_uring_wait_cqe failed: " + std::string(strerror(-ret)));
-            }
-            if (cqe->res < 0) {
-                std::string msg =
-                    "io_uring read error: " + std::string(strerror(-cqe->res));
-                io_uring_cqe_seen(&this->uring_ring, cqe);
-                throw std::runtime_error(msg);
-            }
-            io_uring_cqe_seen(&this->uring_ring, cqe);
-        }
-        // All reads for this chunk are complete; host_buffer is populated.
     };
 
-    int uring_req_id = this->uring_thread->post(std::move(uring_func));
+    if(submit_cnt > 0) {
+        if(unaligned_last_page) {
+            uring_req_id = this->last_page_reader_thread->post(std::move(uring_func));
+        }
+        else {
+            uring_func();
+        }
+    }
+
+    // int uring_req_id = this->uring_thread->post(std::move(uring_func));
 
     // ── cuda_func: runs on cuda_thread ───────────────────────────────────────
     // Waits for uring_thread to finish (SPSC pop: cuda_thread is the sole
@@ -158,7 +145,28 @@ ChunkRequest Loader::post_read_chunk_uring(const ChunkIOParams &p) {
     cudaEvent_t event       = p.event;
 
     auto cuda_func = [=]() {
-        this->uring_thread->pop(uring_req_id);  // wait for I/O completion
+        if(uring_req_id) {
+            this->last_page_reader_thread->pop(uring_req_id);
+        }
+
+        size_t &unfinished_cnt = this->chunks[chunk_id].extra_data.unfinished_cnt;
+        while(unfinished_cnt > 0) {
+            struct io_uring_cqe *cqe;
+            int ret = io_uring_wait_cqe(&this->uring_ring, &cqe);
+            if (ret != 0) {
+                throw std::runtime_error(
+                    "io_uring_wait_cqe failed: " + std::string(strerror(-ret)));
+            }
+            if (cqe->res < 0) {
+                std::string msg =
+                    "io_uring read error: " + std::string(strerror(-cqe->res));
+                io_uring_cqe_seen(&this->uring_ring, cqe);
+                throw std::runtime_error(msg);
+            }
+            chunk_id_t cqe_chunk_id = (chunk_id_t)io_uring_cqe_get_data(cqe);
+            this->chunks[cqe_chunk_id].extra_data.unfinished_cnt --;
+            io_uring_cqe_seen(&this->uring_ring, cqe);
+        }
 
         CUDA_CHECK(cudaMemcpyAsync(rank_dst, rank_mid, rank_size,
                                    cudaMemcpyHostToDevice, this->cuda_stream));

--- a/csrc/loader_io_uring.cpp
+++ b/csrc/loader_io_uring.cpp
@@ -1,0 +1,187 @@
+#include <instant_tensor/loader.hpp>
+#include <liburing.h>
+
+namespace instanttensor {
+
+// ─── Threading model ─────────────────────────────────────────────────────────
+// ALL io_uring calls (get_sqe, submit, wait_cqe, cqe_seen) run exclusively on
+// uring_thread (an SPSCAsyncExecutor).  The main loader thread is the only
+// producer; cuda_thread is the only consumer (via uring_thread->pop).
+//
+// This mirrors the existing aio_fallback_thread pattern and avoids any
+// concurrent access to the liburing userspace state, which is not thread-safe.
+//
+// Within each chunk, the uring_func submits num_threads SQEs simultaneously
+// and then waits for all their CQEs.  The kernel's io-wq dispatches each SQE
+// to a separate worker thread, so all num_threads page-cache fills happen in
+// parallel — unlike libaio, where io_submit serialises the iocbs through
+// generic_file_read_iter one at a time.
+
+// ─── file open / close ───────────────────────────────────────────────────────
+
+void Loader::open_file_uring(FileInfo &f) {
+    // Buffered fd — no O_DIRECT.  Page-cache reads are done by kernel io-wq
+    // workers, which is what makes them truly async with io_uring.
+    f.fd = ::open(f.filename.c_str(), O_RDONLY);
+    if (f.fd < 0) {
+        throw std::runtime_error("Failed to open file: " + f.filename);
+    }
+    struct stat st;
+    if (fstat(f.fd, &st) < 0) {
+        throw std::runtime_error("Failed to fstat file: " + f.filename);
+    }
+    f.size = st.st_size;
+
+    // Hint sequential access so the VFS read-ahead fills the page cache ahead
+    // of our reads and reduces the time spent in the io-wq workers.
+    posix_fadvise(f.fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+
+    this->need_uring       = true;
+    this->need_host_buffer = true;
+    this->need_cuda_thread = true;
+}
+
+void Loader::open_uring_context() {
+    // Ring depth must cover io_depth × num_threads in-flight SQEs.
+    // io_uring_queue_init rounds up internally, but we round up ourselves too
+    // to ensure the ring can hold all in-flight entries without blocking.
+    unsigned needed = (unsigned)(this->io_depth * this->num_threads);
+    unsigned ring_entries = 1;
+    while (ring_entries < needed) ring_entries <<= 1;
+    this->uring_ring_size = ring_entries;
+
+    int ret = io_uring_queue_init(ring_entries, &this->uring_ring, 0);
+    if (ret < 0) {
+        throw std::runtime_error(
+            "io_uring_queue_init failed: " + std::string(strerror(-ret)));
+    }
+}
+
+void Loader::close_file_uring(FileInfo &f) {
+    ::close(f.fd);
+}
+
+void Loader::close_uring_context() {
+    io_uring_queue_exit(&this->uring_ring);
+}
+
+// ─── chunk read ──────────────────────────────────────────────────────────────
+
+// Helper struct capturing the per-segment read parameters, built on the main
+// thread and moved into the uring_func lambda.
+struct UringReadOp {
+    int    fd;
+    void  *buf;
+    size_t size;
+    size_t file_offset;
+};
+
+ChunkRequest Loader::post_read_chunk_uring(const ChunkIOParams &p) {
+    // Build the per-thread read descriptors on the main thread (no io_uring
+    // calls here — those happen exclusively on uring_thread below).
+    std::vector<UringReadOp> ops;
+    ops.reserve(this->num_threads);
+
+    for (size_t i = 0; i < this->num_threads; i++) {
+        size_t thread_offset = p.padded_thread_size * i;
+        size_t thread_size   = std::min(
+            (size_t)std::max((ssize_t)(p.chunk.size - p.rank_offset - thread_offset), (ssize_t)0),
+            p.padded_thread_size);
+        if (thread_size == 0) continue;
+
+        ops.push_back(UringReadOp{
+            p.file.fd,
+            (char*)this->host_buffer + p.window_offset + thread_offset,
+            thread_size,
+            p.chunk.file_offset + p.rank_offset + thread_offset,
+        });
+    }
+
+    // ── uring_func: runs on uring_thread ─────────────────────────────────────
+    // Submits all SQEs then waits for exactly that many CQEs.
+    // Because uring_thread is sequential and chunk N's SQEs are the only ones
+    // in-flight at this point, every CQE must belong to chunk N — no cross-
+    // chunk dispatch needed.
+    auto uring_func = [this, ops = std::move(ops)]() {
+        const size_t submit_cnt = ops.size();
+        if (submit_cnt == 0) return;
+
+        for (const auto &op : ops) {
+            struct io_uring_sqe *sqe = io_uring_get_sqe(&this->uring_ring);
+            if (!sqe) {
+                throw std::runtime_error(
+                    "io_uring SQ full (ring_entries=" +
+                    std::to_string(this->uring_ring_size) + ")");
+            }
+            // Buffered read: no alignment constraints, use exact byte range.
+            io_uring_prep_read(sqe, op.fd, op.buf,
+                               (unsigned)op.size, op.file_offset);
+        }
+
+        int submitted = io_uring_submit(&this->uring_ring);
+        if (submitted < 0) {
+            throw std::runtime_error(
+                "io_uring_submit failed: " + std::string(strerror(-submitted)));
+        }
+
+        // Wait for all submitted reads to complete.
+        // io_uring_wait_cqe blocks until at least one CQE is available;
+        // the kernel's io-wq workers are doing the actual I/O in parallel.
+        for (size_t done = 0; done < submit_cnt; done++) {
+            struct io_uring_cqe *cqe;
+            int ret = io_uring_wait_cqe(&this->uring_ring, &cqe);
+            if (ret < 0) {
+                throw std::runtime_error(
+                    "io_uring_wait_cqe failed: " + std::string(strerror(-ret)));
+            }
+            if (cqe->res < 0) {
+                std::string msg =
+                    "io_uring read error: " + std::string(strerror(-cqe->res));
+                io_uring_cqe_seen(&this->uring_ring, cqe);
+                throw std::runtime_error(msg);
+            }
+            io_uring_cqe_seen(&this->uring_ring, cqe);
+        }
+        // All reads for this chunk are complete; host_buffer is populated.
+    };
+
+    int uring_req_id = this->uring_thread->post(std::move(uring_func));
+
+    // ── cuda_func: runs on cuda_thread ───────────────────────────────────────
+    // Waits for uring_thread to finish (SPSC pop: cuda_thread is the sole
+    // consumer of uring_thread's output queue), then DMA host→GPU.
+    void  *rank_mid         = (char*)this->host_buffer + p.window_offset;
+    void  *rank_dst         = p.rank_dst;
+    void  *all_dst          = p.all_dst;
+    size_t rank_size        = p.rank_size;
+    size_t padded_rank_size = p.padded_rank_size;
+    cudaEvent_t event       = p.event;
+
+    auto cuda_func = [=]() {
+        this->uring_thread->pop(uring_req_id);  // wait for I/O completion
+
+        CUDA_CHECK(cudaMemcpyAsync(rank_dst, rank_mid, rank_size,
+                                   cudaMemcpyHostToDevice, this->cuda_stream));
+        CUDA_CHECK(cudaEventRecord(event, this->cuda_stream));
+        if (this->world_size > 1) {
+            CUDA_CHECK(cudaStreamWaitEvent(this->nccl_stream, event));
+            NCCL_CHECK(ncclAllGather(rank_dst, all_dst, padded_rank_size,
+                                     ncclInt8, this->group_communicator,
+                                     this->nccl_stream));
+            CUDA_CHECK(cudaEventRecord(event, this->nccl_stream));
+        }
+    };
+
+    int cuda_req_id = this->cuda_thread->post(std::move(cuda_func));
+
+    // ── wait_func: runs on wait_thread ───────────────────────────────────────
+    auto wait_func = [=]() mutable {
+        this->cuda_thread->pop(cuda_req_id);
+        CUDA_CHECK(cudaEventSynchronize(event));
+    };
+
+    int completion_req_id = this->wait_thread->post(std::move(wait_func));
+    return ChunkRequest{this->wait_thread.get(), completion_req_id};
+}
+
+} // namespace instanttensor

--- a/instanttensor/_impl.py
+++ b/instanttensor/_impl.py
@@ -377,6 +377,19 @@ class safe_open:
                     concurrency = max(32 // self.world_size, 1) 
                 if io_depth is None:
                     io_depth = 16 # cuFileRead + ncclAllGather # why this has effect?
+            elif os.environ.get('INSTANTTENSOR_USE_URING', '0') == '1': # io_uring buffered
+                if chunk_size is None:
+                    chunk_size = 8*1024*1024
+                if concurrency is None:
+                    # Each SQE dispatches to a separate io-wq kernel worker thread,
+                    # so higher concurrency = more parallel page-cache fills.
+                    # Match fastsafetensors' default of 16 concurrent reads.
+                    concurrency = max(16 // self.world_size, 1)
+                if io_depth is None:
+                    # Pipeline depth: uring_read + cudaMemcpyAsync + ncclAllGather.
+                    # uring_thread is sequential (one chunk at a time), so we only
+                    # need 3 in-flight device buffers, not 512.
+                    io_depth = 3
             else: # aio
                 if chunk_size is None:
                     chunk_size = 8*1024*1024

--- a/instanttensor/_impl.py
+++ b/instanttensor/_impl.py
@@ -16,20 +16,17 @@ except AttributeError:
     # _C module is mocked (e.g., during Sphinx documentation build)
     print("instanttensor._C is mocked, skipping cleanup registration")
 
-_env_debug = None
-_env_use_cufile = None
-
 def env_debug():
-    global _env_debug
-    if _env_debug is None:
-        _env_debug = os.environ.get("INSTANTTENSOR_DEBUG", "0") == "1"
-    return _env_debug
+    return os.environ.get("INSTANTTENSOR_DEBUG", "0") == "1"
 
 def env_use_cufile():
-    global _env_use_cufile
-    if _env_use_cufile is None:
-        _env_use_cufile = os.environ.get("INSTANTTENSOR_USE_CUFILE", "0") == "1"
-    return _env_use_cufile
+    return os.environ.get("INSTANTTENSOR_USE_CUFILE", "0") == "1"
+
+def env_use_uring():
+    return os.environ.get("INSTANTTENSOR_USE_URING", "0") == "1"
+
+def env_direct_io():
+    return os.environ.get("INSTANTTENSOR_DIRECT_IO", "1") == "1"
 
 def env_chunk_size():
     ret = os.environ.get("INSTANTTENSOR_CHUNK_SIZE")
@@ -377,26 +374,21 @@ class safe_open:
                     concurrency = max(32 // self.world_size, 1) 
                 if io_depth is None:
                     io_depth = 16 # cuFileRead + ncclAllGather # why this has effect?
-            elif os.environ.get('INSTANTTENSOR_USE_URING', '0') == '1': # io_uring buffered
-                if chunk_size is None:
-                    chunk_size = 8*1024*1024
-                if concurrency is None:
-                    # Each SQE dispatches to a separate io-wq kernel worker thread,
-                    # so higher concurrency = more parallel page-cache fills.
-                    # Match fastsafetensors' default of 16 concurrent reads.
-                    concurrency = max(16 // self.world_size, 1)
-                if io_depth is None:
-                    # Pipeline depth: uring_read + cudaMemcpyAsync + ncclAllGather.
-                    # uring_thread is sequential (one chunk at a time), so we only
-                    # need 3 in-flight device buffers, not 512.
-                    io_depth = 3
-            else: # aio
-                if chunk_size is None:
-                    chunk_size = 8*1024*1024
-                if concurrency is None:
-                    concurrency = 1 # max(1 // self.world_size, 1)
-                if io_depth is None:
-                    io_depth = max(512 // self.world_size, 3) # aio read + cudaMemcpyAsync + ncclAllGather
+            else: 
+                if env_direct_io(): # io_uring or libaio with O_DIRECT
+                    if chunk_size is None:
+                        chunk_size = 8*1024*1024
+                    if concurrency is None:
+                        concurrency = 1 # max(1 // self.world_size, 1)
+                    if io_depth is None:
+                        io_depth = max(512 // self.world_size, 3) # aio read + cudaMemcpyAsync + ncclAllGather
+                else: # buffered io_uring or libaio
+                    if chunk_size is None:
+                        chunk_size = 8*1024*1024
+                    if concurrency is None:
+                        concurrency = 16
+                    if io_depth is None:
+                        io_depth = max(32 // self.world_size, 3) # aio read + cudaMemcpyAsync + ncclAllGather
         
         if max_free_mem_usage is None:
             max_free_mem_usage = 0.5

--- a/setup.py
+++ b/setup.py
@@ -88,10 +88,11 @@ def get_ext_modules():
                 "csrc/loader_io_cufile.cpp",
                 "csrc/loader_io_aio.cpp",
                 "csrc/loader_io_inmem.cpp",
+                "csrc/loader_io_uring.cpp",
             ],
             include_dirs=include_dirs,
             library_dirs=[libaio_src],
-            libraries=["dl", LIBAIO_LINK_SHORT],
+            libraries=["dl", LIBAIO_LINK_SHORT, "uring"],
             extra_compile_args=cxx_flags,
             extra_link_args=["-Wl,-rpath,$ORIGIN"],
         )


### PR DESCRIPTION
Adds a new I/O backend that uses io_uring with buffered reads (no O_DIRECT) as an alternative to the existing libaio path.

Why io_uring beats libaio-buffered
-----------------------------------
Without O_DIRECT, io_submit() processes each iocb synchronously through generic_file_read_iter -> filemap_read in the calling thread's context, so submitting N iocbs is equivalent to N sequential pread() calls.

io_uring with IORING_OP_READ dispatches each SQE to a separate kernel io-wq worker thread, achieving true parallel page-cache fills even without O_DIRECT.  With concurrency=16 (the new default for this path), 16 kernel workers fill page cache simultaneously per chunk.

Benchmark vs 70B model (H200, cold start):
  aio + no O_DIRECT   141s  0.48 GiB/s  (baseline)
  aio + O_DIRECT      137s  0.49 GiB/s
  fastsafetensors     113s  0.60 GiB/s
  io_uring c=16        28s  2.44 GiB/s  (5x faster than baseline)

Here is a link to more detailed benchmarks: https://docs.google.com/spreadsheets/d/1eQMWcJVxPcUB4gdKGKm8P3MpOZgHpPR3ebnDZr7siJo/edit?usp=sharing 

Changes
-------
- csrc/loader_io_uring.cpp         new: open/close/read via io_uring
- csrc/instant_tensor/loader.hpp   add uring_ring, uring_thread fields
- csrc/instant_tensor/common.hpp   add _env_use_uring() helper
- csrc/loader_common.cpp           wire uring into open/close/read dispatch
- setup.py                         add loader_io_uring.cpp and -luring
- instanttensor/_impl.py           uring branch: concurrency=16, io_depth=3

Usage
-----
  INSTANTTENSOR_USE_URING=1 python -c "import instanttensor; ..."
  INSTANTTENSOR_USE_URING=1 vllm serve <model> --load-format instanttensor

Thread safety
-------------
All io_uring calls (get_sqe, submit, wait_cqe, cqe_seen) run exclusively on a dedicated uring_thread (SPSCAsyncExecutor). This mirrors the aio_fallback_thread pattern and avoids concurrent access to liburing's non-thread-safe userspace SQ/CQ state.

Requires: liburing >= 2.1 (-luring)

