### PR TITLE
Build Linux aarch64 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_dist:
-    name: Build wheels and sdist
+  build_sdist:
+    name: Build sdist
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -32,12 +32,52 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build --sdist
 
+      - uses: actions/upload-artifact@v7
+        with:
+          name: build-sdist
+          path: ./dist/*.tar.gz
+
+  build_wheels:
+    name: Build ${{ matrix.arch }} wheels
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+          fetch-depth: 0
+
+      - name: Custom checkout submodules
+        run: bash ./checkout_submodules.sh
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.0
+        env:
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: build-wheels-${{ matrix.arch }}
+          path: ./wheelhouse/*.whl
+
+  build_dist:
+    name: Collect distributions
+    needs: [build_sdist, build_wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: build-*
+          path: ./dist
+          merge-multiple: true
 
       - uses: actions/upload-artifact@v7
         with:
           name: dist
-          path: |
-            ./wheelhouse/*.whl
-            ./dist/*.tar.gz
+          path: ./dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ where = ["."]
 include = ["instanttensor*"]
 
 [tool.cibuildwheel]
-build = "cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64 cp314-manylinux_x86_64"
+build = "cp310-manylinux_* cp311-manylinux_* cp312-manylinux_* cp313-manylinux_* cp314-manylinux_*"
 
 before-test = "pip install torch --index-url https://download.pytorch.org/whl/cpu"
 test-command = "python -c \"from instanttensor import safe_open\""


### PR DESCRIPTION
## Summary

Add native Linux aarch64 wheel builds alongside the existing x86_64 builds.

## Changes

- Build wheels on native `ubuntu-24.04` and `ubuntu-24.04-arm` runners.
- Make the cibuildwheel selector architecture-neutral.
- Build the source distribution once in a separate job.
- Collect all wheels and the source distribution into the existing `dist` artifact.

## Motivation

InstantTensor currently publishes only x86_64 wheels. On aarch64, package installation falls back to compiling from source, which is especially slow when performed under QEMU during container builds.

Publishing aarch64 wheels avoids that compilation and provides normal binary installation on ARM systems.

## Validation

- `actionlint` passes.
- cibuildwheel resolves the expected CPython 3.10-3.14 wheel identifiers for both `x86_64` and `aarch64`.