### PR TITLE
Support io_uring on Linux 5.6+ with stability warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ InstantTensor is recommended if **any** of the following conditions are met:
 
 - GPU platforms: CUDA, ROCm
 - Framework: PyTorch
+- `URING`/`URING_BUFFERED`: Linux kernel 5.6 or newer; 5.15 or newer is recommended
 
 
 ### Method 1: Install from pip

--- a/csrc/instant_tensor/loader.hpp
+++ b/csrc/instant_tensor/loader.hpp
@@ -139,7 +139,7 @@ public:
     ChunkRequest post_read_chunk_aio(const ChunkIOParams &p);
 
     // io_uring path (loader_io_uring.cpp)
-    static bool uring_available();
+    static BackendStatus uring_status();
     void open_file_uring(FileInfo &f);   // open fd (buffered, no O_DIRECT), fadvise
     void close_file_uring(FileInfo &f);  // close fd
     void initialize_uring_context();           // io_uring_queue_init

--- a/csrc/instant_tensor/types.hpp
+++ b/csrc/instant_tensor/types.hpp
@@ -29,6 +29,12 @@ enum Backend {
     MMAP,
 };
 
+struct BackendStatus {
+    bool available;
+    string reason;
+    string warning;
+};
+
 inline bool is_valid_backend(Backend backend) {
     return backend >= Backend::AIO && backend <= Backend::MMAP;
 }

--- a/csrc/loader_io_uring.cpp
+++ b/csrc/loader_io_uring.cpp
@@ -13,7 +13,23 @@ namespace instanttensor {
 
 namespace {
 
-bool kernel_at_least_5_15() {
+bool is_rhel_family() {
+    FILE *fp = fopen("/proc/version", "r");
+    if (!fp) {
+        return false;
+    }
+    char line[256];
+    bool is_rhel = false;
+    if (fgets(line, sizeof(line), fp)) {
+        if (strstr(line, "Red Hat") != nullptr || strstr(line, ".el") != nullptr) {
+            is_rhel = true;
+        }
+    }
+    fclose(fp);
+    return is_rhel;
+}
+
+bool kernel_at_least_required_version() {
     struct utsname uts;
     if (uname(&uts) != 0) {
         return false;
@@ -31,7 +47,9 @@ bool kernel_at_least_5_15() {
         return false;
     }
 
-    return major > 5 || (major == 5 && minor >= 15);
+    // RHEL 9 backports io_uring stability fixes from 5.15 into kernel 5.14.x
+    int required_minor = is_rhel_family() ? 14 : 15;
+    return major > 5 || (major == 5 && minor >= required_minor);
 }
 
 bool probe_supports_fixed_buffer_read(struct io_uring *ring) {
@@ -74,7 +92,7 @@ bool supports_fixed_buffer_registration(struct io_uring *ring) {
 } // namespace
 
 bool Loader::uring_available(){// best-effort check
-    if (!kernel_at_least_5_15()) { // io_uring with kernel < 5.15 is not reliable
+    if (!kernel_at_least_required_version()) {
         return false;
     }
 

--- a/csrc/loader_io_uring.cpp
+++ b/csrc/loader_io_uring.cpp
@@ -13,42 +13,63 @@ namespace instanttensor {
 
 namespace {
 
-bool kernel_at_least_5_15() {
+struct KernelVersion {
+    long major;
+    long minor;
+    string release;
+};
+
+std::optional<KernelVersion> running_kernel_version() {
     struct utsname uts;
     if (uname(&uts) != 0) {
-        return false;
+        return std::nullopt;
     }
 
     char *end = nullptr;
     long major = strtol(uts.release, &end, 10);
     if (end == uts.release || *end != '.') {
-        return false;
+        return std::nullopt;
     }
 
     const char *minor_start = end + 1;
     long minor = strtol(minor_start, &end, 10);
     if (end == minor_start) {
-        return false;
+        return std::nullopt;
     }
 
-    return major > 5 || (major == 5 && minor >= 15);
+    return KernelVersion{major, minor, uts.release};
 }
 
-bool probe_supports_fixed_buffer_read(struct io_uring *ring) {
+bool kernel_version_at_least(
+    const KernelVersion &version, long required_major, long required_minor) {
+    return version.major > required_major ||
+           (version.major == required_major && version.minor >= required_minor);
+}
+
+bool probe_supports_fixed_buffer_read(struct io_uring *ring, string *reason) {
     struct io_uring_probe *probe = io_uring_get_probe_ring(ring);
     if (!probe) {
+        *reason = "Could not query the supported io_uring opcodes.";
         return false;
     }
 
-    bool supported = io_uring_opcode_supported(probe, IORING_OP_READ) &&
-                     io_uring_opcode_supported(probe, IORING_OP_READ_FIXED);
+    bool supports_read = io_uring_opcode_supported(probe, IORING_OP_READ);
+    bool supports_read_fixed =
+        io_uring_opcode_supported(probe, IORING_OP_READ_FIXED);
     io_uring_free_probe(probe);
-    return supported;
+    if (!supports_read || !supports_read_fixed) {
+        *reason = "The required io_uring READ and READ_FIXED opcodes are unavailable.";
+        return false;
+    }
+    return true;
 }
 
-bool supports_fixed_file_registration(struct io_uring *ring) {
+bool supports_fixed_file_registration(struct io_uring *ring, string *reason) {
     int fd = ::open("/dev/null", O_RDONLY);
     if (fd < 0) {
+        int error = errno;
+        *reason = "Could not open /dev/null while probing io_uring fixed-file "
+                  "registration: " + std::string(strerror(error)) + ".";
         return false;
     }
 
@@ -57,25 +78,49 @@ bool supports_fixed_file_registration(struct io_uring *ring) {
         io_uring_unregister_files(ring);
     }
     ::close(fd);
+    if (ret < 0) {
+        *reason = "io_uring fixed-file registration failed: " +
+                  std::string(strerror(-ret)) + ".";
+    }
     return ret == 0;
 }
 
-bool supports_fixed_buffer_registration(struct io_uring *ring) {
+bool supports_fixed_buffer_registration(struct io_uring *ring, string *reason) {
     char buffer[4096];
     struct iovec iov = {buffer, sizeof(buffer)};
 
     int ret = io_uring_register_buffers(ring, &iov, 1);
     if (ret == 0) {
         io_uring_unregister_buffers(ring);
+    } else {
+        *reason = "io_uring fixed-buffer registration failed: " +
+                  std::string(strerror(-ret)) + ".";
     }
     return ret == 0;
 }
 
 } // namespace
 
-bool Loader::uring_available(){// best-effort check
-    if (!kernel_at_least_5_15()) { // io_uring with kernel < 5.15 is not reliable
-        return false;
+BackendStatus Loader::uring_status(){// best-effort check
+    auto kernel_version = running_kernel_version();
+    if (!kernel_version) {
+        return {false, "Could not determine the Linux kernel version.", ""};
+    }
+
+    // IORING_OP_READ, IOSQE_ASYNC, and IORING_REGISTER_PROBE require 5.6.
+    if (!kernel_version_at_least(*kernel_version, 5, 6)) {
+        return {
+            false,
+            "io_uring requires Linux kernel 5.6 or newer; the detected kernel "
+            "version is " + kernel_version->release + ".",
+            "",
+        };
+    }
+
+    string warning;
+    if (!kernel_version_at_least(*kernel_version, 5, 15)) {
+        warning = "io_uring on Linux " + kernel_version->release +
+                  " may be unstable; Linux 5.15 or newer is recommended.";
     }
 
     struct io_uring ring = {};
@@ -85,16 +130,21 @@ bool Loader::uring_available(){// best-effort check
 
     int ret = io_uring_queue_init_params(2, &ring, &params);
     if (ret < 0) {
-        return false;
+        return {
+            false,
+            "io_uring queue initialization failed: " +
+                std::string(strerror(-ret)) + ".",
+            warning,
+        };
     }
 
     // io_uring_probe reports opcodes; SQPOLL/fixed files are setup/register capabilities.
-    bool supported = // (ring.flags & IORING_SETUP_SQPOLL) &&
-                     probe_supports_fixed_buffer_read(&ring) &&
-                     supports_fixed_file_registration(&ring) &&
-                     supports_fixed_buffer_registration(&ring);
+    string reason;
+    bool supported = probe_supports_fixed_buffer_read(&ring, &reason) &&
+                     supports_fixed_file_registration(&ring, &reason) &&
+                     supports_fixed_buffer_registration(&ring, &reason);
     io_uring_queue_exit(&ring);
-    return supported;
+    return {supported, reason, warning};
 }
 
 void Loader::open_file_uring(FileInfo &f) {

--- a/csrc/main.cpp
+++ b/csrc/main.cpp
@@ -138,15 +138,29 @@ void cleanup() {
     instanttensor::munmaper.reset();
 }
 
-bool backend_available(int backend) {
+BackendStatus backend_status(int backend) {
     Backend backend_enum = static_cast<Backend>(backend);
-    if(backend_enum == Backend::CUFILE) {
-        return Loader::cufile_available();
-    } else if(backend_enum == Backend::URING || backend_enum == Backend::URING_BUFFERED) {
-        return Loader::uring_available();
-    } else {
-        return true;
+    if(!is_valid_backend(backend_enum)) {
+        return {false, "The requested backend is not recognized.", ""};
     }
+    if(backend_enum == Backend::CUFILE) {
+        bool available = Loader::cufile_available();
+        return {
+            available,
+            available ? "" : "cuFile is not available on this system.",
+            "",
+        };
+    }
+    else if(backend_enum == Backend::URING || backend_enum == Backend::URING_BUFFERED) {
+        return Loader::uring_status();
+    }
+    else {
+        return {true, "", ""};
+    }
+}
+
+bool backend_available(int backend) {
+    return backend_status(backend).available;
 }
 
 } // namespace instanttensor
@@ -186,5 +200,13 @@ PYBIND11_MODULE(_C, m) {
 
     m.def("backend_available", &instanttensor::backend_available,
           "Check if the backend is available",
+          pybind11::arg("backend"));
+
+    m.def("backend_status", [](int backend) {
+              auto status = instanttensor::backend_status(backend);
+              return pybind11::make_tuple(
+                  status.available, status.reason, status.warning);
+          },
+          "Return backend availability, rejection reason, and warning",
           pybind11::arg("backend"));
 }

--- a/instanttensor/_impl.py
+++ b/instanttensor/_impl.py
@@ -77,6 +77,7 @@ MAX_IO_DEPTH = 1024
 
 BackendCandidate = Union[Backend, BackendPolicy]
 BackendCandidates = Optional[Union[BackendCandidate, list[BackendCandidate]]]
+_emitted_backend_warnings = set()
 
 
 @dataclass(frozen=True)
@@ -126,21 +127,40 @@ def backend_names(backends: list[Backend]) -> list[str]:
     return [backend.name for backend in backends]
 
 
+def _emit_backend_warning(message: str) -> None:
+    if not message or message in _emitted_backend_warnings:
+        return
+
+    warnings.warn(
+        message,
+        RuntimeWarning,
+        stacklevel=3,
+    )
+    _emitted_backend_warnings.add(message)
+
+
 def select_backend(candidates: list[Backend], supported_backends: Optional[list[Backend]] = None) -> Backend:
     rejected = []
     for backend in candidates:
         if supported_backends is not None and backend not in supported_backends:
-            rejected.append(f"{backend.name} is not supported for this filesystem")
+            rejected.append(f"{backend.name} is not supported for this filesystem.")
             continue
-        if not instanttensor._C.backend_available(backend.value):
-            rejected.append(f"{backend.name} is not available on this system")
+        available, reason, warning = instanttensor._C.backend_status(backend.value)
+        if not available:
+            rejected.append(
+                reason or f"{backend.name} is not available on this system."
+            )
             continue
+        _emit_backend_warning(warning)
         debug_log("Using backend %s", backend.name)
         return backend
 
     candidates_str = ", ".join(backend_names(candidates))
-    rejected_str = "; ".join(rejected)
-    raise RuntimeError(f"No available backend found from candidates [{candidates_str}]. {rejected_str}")
+    rejected_str = " ".join(rejected)
+    raise RuntimeError(
+        f"No available backend was found among candidates [{candidates_str}]. "
+        f"{rejected_str}"
+    )
 
 
 


### PR DESCRIPTION
This extends the original proposal into a distro-independent check based on the io_uring operations InstantTensor uses.

- Require Linux 5.6 or newer for io_uring backends.
- Warn that kernels older than 5.15 may be unstable.
- Keep functional probes for queue creation, required opcodes, fixed files, and fixed buffers.
- Return complete availability reasons and warnings from C++ for Python to display.
- Document the minimum and recommended kernel versions.

The original contribution from @aleskandro remains in the commit history.

Validated by rebuilding the native extension, running 20 parameter and backend-selection tests, and comparing all 104 tensors in a real safetensors model against the reference loader with no mismatches.